### PR TITLE
Fix EXC_BAD_ACCESS

### DIFF
--- a/Daily Dashboard/ViewController.swift
+++ b/Daily Dashboard/ViewController.swift
@@ -55,7 +55,7 @@ class ViewController: UIViewController {
         locationManager.requestWhenInUseAuthorization()
         locationManager.requestLocation()
         
-        theWeather.getWeatherData { (currentWeather) in
+        theWeather.getWeatherData(for: self.appleTVlocation()) { (currentWeather) in
             print(currentWeather)
         }
     }

--- a/Daily Dashboard/Weather.swift
+++ b/Daily Dashboard/Weather.swift
@@ -8,9 +8,6 @@
 
 import Foundation
 class OpenWeatherAPI {
-    
-    var viewController = ViewController()
-    lazy var appleTVlocation = viewController.appleTVlocation()
    
     //    struct coordinates: Codable {
     //        let longitude: Double
@@ -56,7 +53,7 @@ class OpenWeatherAPI {
     //    }
     
     
-    func getWeatherData(completion:  @escaping (WeatherAPI) -> Void) {
+    func getWeatherData(for appleTVlocation:(Double, Double), completion: @escaping (WeatherAPI) -> Void) {
         let lat = appleTVlocation.0
         let long = appleTVlocation.1
         let jsonUrlString = "http://api.openweathermap.org/data/2.5/weather?lat=\(lat)&lon=\(long)&APPID=8b29a4bca59654d89101420102680ded"


### PR DESCRIPTION
@travisbrigman Looked like there was a memory management problem, which was shown by the app crashing with an error of EXC_BAD_ACCESS. There was a strange pattern where a separate ViewController instance was being created in the Weather class. However, since that instance was separate from the main ViewController instance instantiated by the app, it did not have access to the appleTVlocation. This was causing the app to try and access something that did not exist. Instead, a typical pattern is to pass the API helper methods any state they need to carry out their request. Here, we pass the appleTVlocation from the ViewController, instead of trying to internalize that state in the API helper class (Weather).