### PR TITLE
Updated function call to properly set the background image.

### DIFF
--- a/Daily Dashboard/ViewController.swift
+++ b/Daily Dashboard/ViewController.swift
@@ -51,12 +51,10 @@ class ViewController: UIViewController {
         timer.fire()
         
         // calls the background image function
-        let backgroundImageInstance = getBackroundImage(completion: image)
-
-        backgroundImageInstance.getBackgroundImage { (image)
+        getBackroundImage { (image) in
 
             DispatchQueue.main.async {
-                mainView.background.image = image
+                self.background.image = image
             }
         }
         


### PR DESCRIPTION
@travisbrigman a few updates here. Your `getBackgroundImage` function is not in a class, which means it's in the global namespace and can be called from anywhere like I did in this update. There's also a bit of syntactical sugar in the way the completion handler is passed to `getBackgroundImage` in this update. If a closure is the last argument in a function call, you can add the closure like I did here. Check out the section on Trailing Closures at the link below for more info.

https://docs.swift.org/swift-book/LanguageGuide/Closures.html